### PR TITLE
Fix ios location request for Always case

### DIFF
--- a/ios/Classes/LocationPlugin.m
+++ b/ios/Classes/LocationPlugin.m
@@ -34,12 +34,12 @@
         if ([CLLocationManager locationServicesEnabled]) {
             self.clLocationManager = [[CLLocationManager alloc] init];
             self.clLocationManager.delegate = self;
-            if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
-                [self.clLocationManager requestWhenInUseAuthorization];
-            }
-            else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
+            if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
                 [self.clLocationManager requestAlwaysAuthorization];
             }
+            else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
+                 [self.clLocationManager requestWhenInUseAuthorization];
+             }
             else {
                 [NSException raise:NSInternalInconsistencyException format:@"To use location in iOS8 you need to define either NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in the app bundle's Info.plist file"];
             }


### PR DESCRIPTION
Reorder test made on Info.plist for requesting location. Test first if it is a NSLocationAlwaysUsageDescription then NSLocationWhenInUseUsageDescription because since ios 10 NSLocationWhenInUseUsageDescription is required with NSLocationAlwaysUsageDescription